### PR TITLE
ルーティングの編集

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
-  root to: 'messages#index'
+  devise_for :users
+  root 'groups#index'
+  resources :users, only: [:index, :edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update] do
+    resources :messages, only: [:index]
+  end
 end


### PR DESCRIPTION
#what
root_pathを'messages#index'から'groups#index'に変更

#why
groupのindex画面から、ネストさせたmessage画面を表示させたいため